### PR TITLE
Also set date, which shows on iPad status bars

### DIFF
--- a/nine41.swift
+++ b/nine41.swift
@@ -50,7 +50,10 @@ extension Process {
     /// Executes `xcrun simctl status_bar` on the specified device.
     ///
     /// - Parameter device: The device for which status bar values should be overridden.
-    func xcrun_fix_status_bar(_ device: String, time: String) {
+    func xcrun_fix_status_bar(_ device: String) {
+        let magicDate = Date(timeIntervalSince1970: 1168364460) // 9:41 AM PT on Tuesday January 9, 2007
+        let time = ISO8601DateFormatter().string(from: magicDate)
+
         self.xcrun(
             "simctl", "status_bar", device, "override",
             "--time", time,
@@ -63,22 +66,6 @@ extension Process {
             "--batteryLevel", "100"
         )
     }
-
-    func get_time_in_current_time_zone(_ timestamp: Int) -> String {
-        self.launchPath = "/usr/bin/env"
-        self.arguments = ["date", "-r", String(timestamp), "+%FT%T%z"]
-
-        let pipe = Pipe()
-        self.standardOutput = pipe
-
-        self.launch()
-        self.waitUntilExit()
-
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        let output: String = NSString(data: data, encoding: String.Encoding.utf8.rawValue)! as String
-
-        return output
-    }
 }
 
 print("Fixing status bars...")
@@ -87,9 +74,6 @@ let deviceData = Process().xcrun_list_devices()
 let json = (try! JSONSerialization.jsonObject(with: deviceData, options: [])) as! Dictionary<String, Any>
 let runtimes = json["devices"] as! Dictionary<String, Array<Any>>
 let allDevices = runtimes.values.flatMap { $0 } as! Array<Dictionary<String, AnyHashable>>
-
-// 9:41 AM PT on Tuesday January 9, 2007
-let magicTime = Process().get_time_in_current_time_zone(1168364460)
 
 var fixed = false
 
@@ -100,7 +84,7 @@ allDevices.forEach {
     let udid = $0["udid"] as! String
 
     if available && state != "Shutdown" {
-        Process().xcrun_fix_status_bar(udid, time: magicTime)
+        Process().xcrun_fix_status_bar(udid)
         print("✅ \(name), \(udid)")
         fixed = true
     }


### PR DESCRIPTION
iPad status bars also show the date, so I wanted to set that to the appropriate date for 9:41am.

`simctl` allows setting the date with the `time` arg, but it needs to be ISO format. That means the time we include in the ISO date string needs to be in the current time zone. So we need to get that at runtime from the system. Per [this answer on SO](https://stackoverflow.com/a/59071895/203773) we can get that from the system via `date`.

This PR adds another function to shell out and get that magic date string, and passes it into `xcrun_fix_status_bar` for use as the `time` argument.

This is what we get in the simulator:

<img width="146" alt="Screen Shot 2020-04-01 at 2 44 35 PM" src="https://user-images.githubusercontent.com/21501/78189865-ba844a80-7427-11ea-997b-1edfe379258b.png">
