### PR TITLE
Add support for CocoaPods

### DIFF
--- a/Nine41.podspec
+++ b/Nine41.podspec
@@ -1,38 +1,18 @@
-#
-# Be sure to run `pod lib lint Nine41.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
-  s.name             = 'Nine41'
-  s.version          = '2.0.1'
-  s.summary          = 'Automate overriding the status bars for all running iOS simulators'
+  s.name = 'Nine41'
+  s.version = '2.1.0'
+  s.license = 'MIT'
 
-  s.description      = <<-DESC
-  This script fixes most of the issues with `simclt status_bar` that shipped with Xcode 11. It overrides the status bars for all currently running simulators using "Apple's defaults" — full cellular bars, full wifi bars, full battery, no "carrier" name, and 9:41 for the time.
-                       DESC
-
-  s.homepage         = 'https://www.jessesquires.com/'
-  # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
-  s.license          = { :type => 'MIT', :file => 'LICENSE' }
-  s.author           = { 'Jesse Squires' => 'email@email.com' }
-  s.source           = { :git => 'https://github.com/jessesquires/Nine41.git', :tag => s.version.to_s }
+  s.summary = 'Automate overriding the status bars for all running iOS simulators'
+  s.homepage = 'https://github.com/jessesquires/Nine41'
   s.social_media_url = 'https://twitter.com/jesse_squires'
+  s.author = 'Jesse Squires'
+
+  s.source = { :git => 'https://github.com/jessesquires/Nine41.git', :tag => s.version }
+  s.source_files = 'Sources/**/*'
+
+  s.source_files = 'Sources/**/*'
 
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.15'
-  s.swift_version = '5.0'
-
-  s.source_files = 'Sources/**/*'
-  
-  # s.resource_bundles = {
-  #   'Nine41' => ['Nine41/Assets/*.png']
-  # }
-
-  # s.public_header_files = 'Pod/Classes/**/*.h'
-  # s.frameworks = 'UIKit', 'MapKit'
-  # s.dependency 'AFNetworking', '~> 2.3'
 end

--- a/Nine41.podspec
+++ b/Nine41.podspec
@@ -1,0 +1,38 @@
+#
+# Be sure to run `pod lib lint Nine41.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'Nine41'
+  s.version          = '2.0.1'
+  s.summary          = 'Automate overriding the status bars for all running iOS simulators'
+
+  s.description      = <<-DESC
+  This script fixes most of the issues with `simclt status_bar` that shipped with Xcode 11. It overrides the status bars for all currently running simulators using "Apple's defaults" — full cellular bars, full wifi bars, full battery, no "carrier" name, and 9:41 for the time.
+                       DESC
+
+  s.homepage         = 'https://www.jessesquires.com/'
+  # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'Jesse Squires' => 'email@email.com' }
+  s.source           = { :git => 'https://github.com/jessesquires/Nine41.git', :tag => s.version.to_s }
+  s.social_media_url = 'https://twitter.com/jesse_squires'
+
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.15'
+  s.swift_version = '5.0'
+
+  s.source_files = 'Sources/**/*'
+  
+  # s.resource_bundles = {
+  #   'Nine41' => ['Nine41/Assets/*.png']
+  # }
+
+  # s.public_header_files = 'Pod/Classes/**/*.h'
+  # s.frameworks = 'UIKit', 'MapKit'
+  # s.dependency 'AFNetworking', '~> 2.3'
+end

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ dependencies: [
 ]
 ```
 
+### CocoaPods
+
+pod 'Nine41'
+
 Alternatively, you can add the package [directly via Xcode](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app).
 
 ## Usage
@@ -75,8 +79,14 @@ As described [in this post](https://www.jessesquires.com/blog/2020/04/13/fully-a
 1. Add the Swift package to your Xcode project
 2. Add a "Run Script" build phase with the following:
 
+If installed via Swift Package Manager, use:
 ```bash
 /usr/bin/xcrun --sdk macosx swift run --package-path "${BUILD_ROOT}/../../SourcePackages/checkouts/Nine41"
+```
+
+For CocoaPods installations, use:
+```bash
+/usr/bin/xcrun --sdk macosx swift "${PODS_ROOT}/Nine41/Sources/main.swift"
 ```
 
 3. Build and run. Note that simulators must be booted for the script to work.

--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ dependencies: [
 ]
 ```
 
-### CocoaPods
-
-pod 'Nine41'
-
 Alternatively, you can add the package [directly via Xcode](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app).
+
+### [CocoaPods](https://cocoapods.org)
+
+```ruby
+pod 'Nine41'
+```
 
 ## Usage
 
@@ -79,17 +81,19 @@ As described [in this post](https://www.jessesquires.com/blog/2020/04/13/fully-a
 1. Add the Swift package to your Xcode project
 2. Add a "Run Script" build phase with the following:
 
-If installed via Swift Package Manager, use:
+For Swift Package Manager installations:
+
 ```bash
 /usr/bin/xcrun --sdk macosx swift run --package-path "${BUILD_ROOT}/../../SourcePackages/checkouts/Nine41"
 ```
 
-For CocoaPods installations, use:
+For CocoaPods installations:
+
 ```bash
 /usr/bin/xcrun --sdk macosx swift "${PODS_ROOT}/Nine41/Sources/main.swift"
 ```
 
-3. Build and run. Note that simulators must be booted for the script to work.
+3. Build and run. Note that simulators must be booted for the script to work, which means the very first run may not produce results but the subsequent runs will.
 
 ## Contributing
 

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -22,6 +22,7 @@ extension StringProtocol {
     }
 }
 
+#if os(OSX)
 extension Process {
     /// Creates a process to execute `xcrun`.
     ///
@@ -95,3 +96,4 @@ allDevices.forEach {
 if !fixed {
     print("❌ No simulators are running. Launch the iOS simulator first.")
 }
+#endif


### PR DESCRIPTION
🖤 

As per your [blog post](https://www.jessesquires.com/blog/2020/04/13/fully-automating-perfect-status-bar-overrides-for-ios-simulators/), I have made a PR that adds support for CocoaPods.

## Describe your changes

Added a `.podspec` file. It has an iOS deployment target added, but this is to ensure CocoaPods adds the source to your project. In order to make it compile for iOS, I wrapped most of the code in `main.swift` with a platform check `#if os(OSX)`. I also chose Swift 5.0 instead of 5.2, hope that's ok.

The readme was updated with CocoaPods instructions. The pod install instruction won't work until the pod is actually [published to trunk](https://guides.cocoapods.org/making/getting-setup-with-trunk).

For testing, I use the following:
```
pod 'Nine41', :git => 'https://github.com/ricsantos/Nine41.git', :branch => 'cocoapods'
```

as I found that the source wasn't copied in using the `:path =>` directive (not sure if I did something wrong here).

The build script phase is similar to the SPM one:
```
/usr/bin/xcrun --sdk macosx swift "${PODS_ROOT}/Nine41/Sources/main.swift"
```

Note I used `swift ... main.swift` instead of `swift run ... main.swift` as the former is deprecated.

On first launch the simulator status bar seems not to update, but it does on subsequent launches.

The timezone is incorrect as per #10 


